### PR TITLE
Add fluid name header inside hero section

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -5,7 +5,7 @@ layout: default
 <section class="hero">
   <div class="hero-left">
     <h1 class="hero-heading">{{ page.hero_heading }}</h1>
-    <div class="page-name-header">{{ page.name_header}}</div>
+    <h2 class="page-name-header">{{ page.name_header }}</h2>
     <p class="hero-subheading">{{ page.hero_subheading }}</p>
     <p class="hero-tagline">{{ page.hero_tagline }}</p>
     <a class="cta-btn" href="{{ page.cta_url | relative_url }}">{{ page.cta_label }} &rarr;</a>

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -2,6 +2,8 @@
 layout: default
 ---
 
+<div class="page-name-header">Brian O'Byrne</div>
+
 <section class="hero">
   <div class="hero-left">
     <h1 class="hero-heading">{{ page.hero_heading }}</h1>

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -2,11 +2,10 @@
 layout: default
 ---
 
-<div class="page-name-header">Brian O'Byrne</div>
-
 <section class="hero">
   <div class="hero-left">
     <h1 class="hero-heading">{{ page.hero_heading }}</h1>
+    <div class="page-name-header">{{ page.name_header}}</div>
     <p class="hero-subheading">{{ page.hero_subheading }}</p>
     <p class="hero-tagline">{{ page.hero_tagline }}</p>
     <a class="cta-btn" href="{{ page.cta_url | relative_url }}">{{ page.cta_label }} &rarr;</a>

--- a/assets/main.scss
+++ b/assets/main.scss
@@ -147,8 +147,7 @@ body.home .page-content > .wrapper {
   font-weight: 300;
   color: $text-hero;
   letter-spacing: -0.03em;
-  margin: 0;
-  margin-bottom: 16px;
+  margin: 0 0 16px;
   white-space: nowrap;
   overflow: hidden;
 }

--- a/assets/main.scss
+++ b/assets/main.scss
@@ -143,22 +143,14 @@ body.home .page-content > .wrapper {
 
 .page-name-header {
   font-family: 'Fraunces', serif;
-  font-size: 72px;
+  font-size: clamp(52px, 8vw, 88px);
   font-weight: 300;
   color: $text-hero;
   letter-spacing: -0.03em;
   margin: 0;
-  padding: 48px 32px 24px;
-  border-bottom: 1px solid $border;
-
-  @media (max-width: 900px) {
-    font-size: 48px;
-  }
-
-  @media (max-width: 680px) {
-    font-size: 36px;
-    padding: 24px 32px 16px;
-  }
+  margin-bottom: 16px;
+  white-space: nowrap;
+  overflow: hidden;
 }
 
 // ─── Hero ─────────────────────────────────────────────────────────────────────

--- a/assets/main.scss
+++ b/assets/main.scss
@@ -139,6 +139,28 @@ body.home .page-content > .wrapper {
   }
 }
 
+// ─── Page name header ─────────────────────────────────────────────────────────
+
+.page-name-header {
+  font-family: 'Fraunces', serif;
+  font-size: 72px;
+  font-weight: 300;
+  color: $text-hero;
+  letter-spacing: -0.03em;
+  margin: 0;
+  padding: 48px 32px 24px;
+  border-bottom: 1px solid $border;
+
+  @media (max-width: 900px) {
+    font-size: 48px;
+  }
+
+  @media (max-width: 680px) {
+    font-size: 36px;
+    padding: 24px 32px 16px;
+  }
+}
+
 // ─── Hero ─────────────────────────────────────────────────────────────────────
 
 .hero {

--- a/index.md
+++ b/index.md
@@ -1,7 +1,8 @@
 ---
 layout: home
 title: Home
-hero_heading: "Driven by curiosity<br><em>Engineered with intent</em><br>Ever adaptive"
+name_header: "Brian O'Byrne"
+hero_heading: "Driven by curiosity<br><em>Engineering with intent</em><br>Ever adaptive"
 hero_subheading: "My mission:"
 hero_tagline: "To explore new systems<br>To seek out new ideas and new technologies<br>To build what hasn't been built before"
 cta_label: "See my apps"


### PR DESCRIPTION
## Summary

- Adds a prominent "Brian O'Byrne" name header inside `.hero-left`, positioned between the hero heading and hero subheading
- Font size is fluid via `clamp(52px, 8vw, 88px)` with `white-space: nowrap` and `overflow: hidden` to guarantee single-line rendering at all viewport widths
- Name is wired to `page.name_header` front matter in `index.md` for easy copy changes
- Also updates hero heading copy: "Engineered with intent" → "Engineering with intent" (active present tense)

## Test plan

- [x] Name renders on one line at 320px, 375px, 680px, 900px, 1280px, and 1600px+
- [x] Font size scales fluidly — visibly larger at wider viewports, no step jumps
- [x] No horizontal scrollbar at any viewport width
- [x] Name is absent from /projects/, blog, and individual project/post pages
- [x] Hero layout (two columns → single column at ≤680px), app cards, about strip, and footer all intact